### PR TITLE
test: add data-integrity and getSubstateKey unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,13 @@ jobs:
           done
       - name: Validate bundled TopoJSON
         run: node -e "JSON.parse(require('fs').readFileSync('data/us-states.json', 'utf8'))"
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run test suite
+        run: node --test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ### Added
 
+- Test suite (`test/`) — the first automated tests. Tier 1 data-integrity invariants (`test/data-integrity.test.js`) guard against the documented gray-`#888` failure mode and dropped-state bug; Tier 2 unit tests (`test/getsubstate.test.js`) pin `getSubstateKey`'s boundary overrides on both sides of every line. Runs on `node --test` with zero dependencies. Adds a `test` job to CI and a minimal test-only `package.json` (site stays dependency-free). Implements the first steps of `docs/testing-strategy.md`.
 - `docs/testing-strategy.md` — test coverage analysis and a tiered testing proposal (data-integrity invariants, `getSubstateKey` unit tests, rendering-pipeline integration, browser smoke test) for the currently untested codebase.
 - `README.md` — quick-start, sovereignty sequence summary, file map.
 - `scripts/init-labels.sh` and `scripts/protect-main.sh` from WorldRover canon.

--- a/js/territories.js
+++ b/js/territories.js
@@ -239,3 +239,11 @@ const SEQUENCE_COLORS = {
   'Spain→Mexico→Bear Flag Republic→USA':                    '#e8a838',  // gold (Bear Flag / CA)
   'Spain+Russia→Britain+USA→USA':                           '#ff9da7',  // pink (Oregon Country)
 };
+
+// Node interop for tests — inert in the browser (no `module` global there).
+// Keeps territories.js a plain browser global while letting `node --test` import it.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    FIPS_TO_STATE, STATE_SOVEREIGNTY, SEQUENCE_INFO, SEQUENCE_COLORS, getSubstateKey,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "blockparty",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Test-only tooling for the blockparty static site. The shipped site remains dependency-free and CDN-loaded; this manifest exists solely to run the Node test suite. CHANGELOG.md remains the source of truth for releases (see CLAUDE.md).",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/test/data-integrity.test.js
+++ b/test/data-integrity.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+// Tier 1 — data-integrity invariants over the sovereignty data layer.
+// These guard the failure modes documented in CLAUDE.md: a key with no color
+// renders gray (#888); a FIPS state with no sequence is dropped from the grid.
+// See docs/testing-strategy.md.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  FIPS_TO_STATE,
+  STATE_SOVEREIGNTY,
+  SEQUENCE_INFO,
+  SEQUENCE_COLORS,
+  getSubstateKey,
+} = require('../js/territories.js');
+
+// Joined lookup keys produced by the state-level table.
+const stateKeys = new Set(
+  Object.values(STATE_SOVEREIGNTY).map((seq) => seq.join('→')),
+);
+
+// Keys returnable by getSubstateKey: every quoted string literal containing the
+// '→' joiner inside the function body. Scoped to the function source so we never
+// pick up the spaced labels ("Britain → USA") from SEQUENCE_INFO.
+// Sequence keys contain only letters, spaces, '+' and the '→' joiner — never
+// punctuation, digits, or newlines. Constraining the class this way keeps the
+// match from spanning comment text (which also contains '→').
+const overrideKeys = new Set(
+  [...getSubstateKey.toString().matchAll(/(['"])([A-Za-z][A-Za-z +→]*→[A-Za-z +→]*)\1/g)]
+    .map((m) => m[2]),
+);
+
+// Every key the renderer can ever look up.
+const reachableKeys = new Set([...stateKeys, ...overrideKeys]);
+
+const colorKeys = new Set(Object.keys(SEQUENCE_COLORS));
+const infoKeys = new Set(Object.keys(SEQUENCE_INFO));
+
+test('getSubstateKey source exposes the expected override keys', () => {
+  // Guards the extraction above — if the regex silently matched nothing, the
+  // "every reachable key has a color" test would pass vacuously for overrides.
+  assert.ok(overrideKeys.size >= 5, `expected >=5 override keys, got ${overrideKeys.size}`);
+});
+
+test('every reachable key has a SEQUENCE_COLORS entry (no gray #888 cells)', () => {
+  const missing = [...reachableKeys].filter((k) => !colorKeys.has(k));
+  assert.deepEqual(missing, [], `keys missing a color: ${missing.join(', ')}`);
+});
+
+test('every reachable key has a SEQUENCE_INFO entry (tooltip/legend)', () => {
+  const missing = [...reachableKeys].filter((k) => !infoKeys.has(k));
+  assert.deepEqual(missing, [], `keys missing info: ${missing.join(', ')}`);
+});
+
+test('SEQUENCE_COLORS and SEQUENCE_INFO cover the same key set (no orphans)', () => {
+  const colorNotInfo = [...colorKeys].filter((k) => !infoKeys.has(k));
+  const infoNotColor = [...infoKeys].filter((k) => !colorKeys.has(k));
+  assert.deepEqual(colorNotInfo, [], `in COLOR but not INFO: ${colorNotInfo.join(', ')}`);
+  assert.deepEqual(infoNotColor, [], `in INFO but not COLOR: ${infoNotColor.join(', ')}`);
+});
+
+test('no dead SEQUENCE_COLORS entries (every color is reachable)', () => {
+  const dead = [...colorKeys].filter((k) => !reachableKeys.has(k));
+  assert.deepEqual(dead, [], `unreachable color entries: ${dead.join(', ')}`);
+});
+
+test('every color is a valid #rrggbb hex', () => {
+  for (const [key, hex] of Object.entries(SEQUENCE_COLORS)) {
+    assert.match(hex, /^#[0-9a-fA-F]{6}$/, `${key} has invalid hex ${hex}`);
+  }
+});
+
+test('no two sequences share a color', () => {
+  const byHex = {};
+  for (const [key, hex] of Object.entries(SEQUENCE_COLORS)) {
+    (byHex[hex.toLowerCase()] ||= []).push(key);
+  }
+  const dupes = Object.entries(byHex).filter(([, keys]) => keys.length > 1);
+  assert.deepEqual(dupes, [], `duplicate colors: ${JSON.stringify(dupes)}`);
+});
+
+test('every SEQUENCE_INFO entry has a non-empty label', () => {
+  for (const [key, info] of Object.entries(SEQUENCE_INFO)) {
+    assert.ok(info.label && info.label.length > 0, `${key} has no label`);
+  }
+});
+
+test('every continental FIPS maps to a state with a sequence (not dropped from grid)', () => {
+  const orphans = Object.entries(FIPS_TO_STATE)
+    .filter(([, abbr]) => !STATE_SOVEREIGNTY[abbr])
+    .map(([fips, abbr]) => `${fips}->${abbr}`);
+  assert.deepEqual(orphans, [], `FIPS states with no sequence: ${orphans.join(', ')}`);
+});
+
+test('every sequence state is reachable from a FIPS code', () => {
+  const fipsStates = new Set(Object.values(FIPS_TO_STATE));
+  const unreachable = Object.keys(STATE_SOVEREIGNTY).filter((abbr) => !fipsStates.has(abbr));
+  assert.deepEqual(unreachable, [], `sequence states with no FIPS: ${unreachable.join(', ')}`);
+});
+
+test('FIPS keys are 2-digit zero-padded strings', () => {
+  for (const fips of Object.keys(FIPS_TO_STATE)) {
+    assert.match(fips, /^\d{2}$/, `bad FIPS key: ${fips}`);
+  }
+});
+
+test('FIPS values are unique 2-letter uppercase abbreviations', () => {
+  const abbrs = Object.values(FIPS_TO_STATE);
+  for (const abbr of abbrs) {
+    assert.match(abbr, /^[A-Z]{2}$/, `bad abbreviation: ${abbr}`);
+  }
+  assert.equal(new Set(abbrs).size, abbrs.length, 'duplicate abbreviation in FIPS_TO_STATE');
+});
+
+test('deliberate exclusions stay excluded (AK, HI, and territories)', () => {
+  // CLAUDE.md: continental US only — non-continental FIPS must not appear.
+  for (const fips of ['02' /* AK */, '15' /* HI */, '72' /* PR */, '11' /* DC */]) {
+    assert.ok(!(fips in FIPS_TO_STATE), `FIPS ${fips} should be excluded`);
+  }
+});
+
+test('every sequence is non-empty, clean, and terminates at USA', () => {
+  for (const [abbr, seq] of Object.entries(STATE_SOVEREIGNTY)) {
+    assert.ok(Array.isArray(seq) && seq.length > 0, `${abbr} has an empty sequence`);
+    assert.equal(seq[seq.length - 1], 'USA', `${abbr} does not end at USA`);
+    for (const power of seq) {
+      assert.ok(typeof power === 'string' && power.trim().length > 0, `${abbr} has a blank entry`);
+    }
+  }
+});

--- a/test/getsubstate.test.js
+++ b/test/getsubstate.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+// Tier 2 — unit tests for getSubstateKey, the sub-state boundary overrides.
+// Each override is a linear approximation of a historical line; these cases pin
+// the current behavior on both sides of every boundary so a tuning pass shows up
+// as an explicit, reviewed diff rather than a silent shift. See
+// docs/testing-strategy.md.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { getSubstateKey } = require('../js/territories.js');
+
+const OREGON = 'Spain+Russia→Britain+USA→USA';
+const LOUISIANA = 'France→Spain→France→USA';
+const MEX_CESSION = 'Spain→Mexico→USA';
+const BRITAIN = 'Britain→USA';
+const WEST_FL_REPUBLIC = 'Spain→Britain→Spain→Republic of West Florida→USA';
+const WEST_FL_COAST = 'Spain→Britain→Spain→USA';
+const NUECES = 'Spain→Mexico→Disputed→USA';
+const NO_MANS_LAND = 'Spain→Mexico→Republic of Texas→Unorganized→USA';
+
+// { name, abbr, lon, lat, expected }
+const cases = [
+  // Minnesota — Mississippi River split (east of the river was Britain→USA).
+  ['MN east of Mississippi', 'MN', -92.0, 45.0, BRITAIN],
+  ['MN west of Mississippi', 'MN', -95.0, 45.0, LOUISIANA],
+  ['MN clamp above the river source (lat > 47.2)', 'MN', -94.0, 48.0, BRITAIN],
+
+  // Montana — Continental Divide (west of the divide was Oregon Country).
+  ['MT west of divide', 'MT', -114.0, 46.0, OREGON],
+  ['MT east of divide falls through', 'MT', -110.0, 46.0, null],
+
+  // Wyoming — Continental Divide.
+  ['WY west of divide', 'WY', -110.5, 43.0, OREGON],
+  ['WY east of divide falls through', 'WY', -106.0, 43.0, null],
+
+  // Colorado — Continental Divide at ~106°W (west was the Mexican Cession).
+  ['CO west of divide', 'CO', -108.0, 39.0, MEX_CESSION],
+  ['CO east of divide falls through', 'CO', -104.0, 39.0, null],
+
+  // Louisiana — Florida Parishes east of the Mississippi, below 31.5°N.
+  ['LA Florida Parishes (east of river, south of 31.5)', 'LA', -90.5, 30.8, WEST_FL_REPUBLIC],
+  ['LA west of the river falls through', 'LA', -93.0, 30.8, null],
+  ['LA north of 31.5 falls through', 'LA', -90.0, 32.0, null],
+
+  // Mississippi — West Florida coast below 30.5°N.
+  ['MS Gulf coast', 'MS', -88.9, 30.3, WEST_FL_COAST],
+  ['MS interior falls through', 'MS', -89.5, 33.0, null],
+
+  // Alabama — Mobile Bay / West Florida coast below 31.0°N.
+  ['AL Mobile Bay coast', 'AL', -88.0, 30.6, WEST_FL_COAST],
+  ['AL interior falls through', 'AL', -86.8, 33.0, null],
+
+  // Texas — Nueces Strip between the Nueces River and the Rio Grande.
+  ['TX Nueces Strip near Rio Grande', 'TX', -99.0, 27.0, NUECES],
+  ['TX north of the Nueces line falls through', 'TX', -99.0, 32.0, null],
+
+  // Oklahoma — the Panhandle ("No Man's Land") west of 100°W.
+  ['OK Panhandle', 'OK', -101.0, 36.7, NO_MANS_LAND],
+  ['OK main body falls through', 'OK', -97.0, 35.5, null],
+];
+
+for (const [name, abbr, lon, lat, expected] of cases) {
+  test(name, () => {
+    assert.equal(getSubstateKey(lon, lat, abbr), expected);
+  });
+}
+
+test('states with no override return null', () => {
+  for (const abbr of ['CA', 'NY', 'FL', 'VA', 'AZ']) {
+    assert.equal(getSubstateKey(-100, 40, abbr), null, `${abbr} should fall through`);
+  }
+});
+
+test('every returned override key is one of the documented sequences', () => {
+  const allowed = new Set([
+    OREGON, LOUISIANA, MEX_CESSION, BRITAIN,
+    WEST_FL_REPUBLIC, WEST_FL_COAST, NUECES, NO_MANS_LAND,
+  ]);
+  for (const [name, abbr, lon, lat] of cases) {
+    const key = getSubstateKey(lon, lat, abbr);
+    if (key !== null) {
+      assert.ok(allowed.has(key), `${name} returned unexpected key ${key}`);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- Adds the project's **first automated tests**, implementing Tiers 1–2 of `docs/testing-strategy.md`. Runs on `node --test` with **zero dependencies**; 36 tests pass.
- **Tier 1** (`test/data-integrity.test.js`): invariants over the sovereignty data layer — every reachable key (state-level + `getSubstateKey` override literals) has a `SEQUENCE_COLORS` **and** `SEQUENCE_INFO` entry (guards the documented gray-`#888` failure mode), color/info key symmetry, no dead entries, valid unique hexes, FIPS↔sequence completeness (guards states silently dropped from the grid), FIPS shape, and sequence sanity (non-empty, terminates at `USA`).
- **Tier 2** (`test/getsubstate.test.js`): table-driven tests pinning `getSubstateKey` on **both sides of every override boundary** (MN Mississippi, MT/WY/CO Continental Divide, LA/MS/AL West Florida coast, TX Nueces Strip, OK Panhandle), plus clamp behavior and fall-through for unlisted states — so a future boundary-tuning pass surfaces as an explicit, reviewed diff.
- Supporting changes: a guarded `module.exports` on `js/territories.js` (inert in the browser — no `module` global there), a minimal **test-only** `package.json` (`"private": true`; the shipped site stays dependency-free and CDN-loaded, and `CHANGELOG.md` remains the release source of truth per `CLAUDE.md`), and a `test` job in `.github/workflows/ci.yml`.

## Test plan

- `node --test` (or `npm test`) → 36 passing, 0 failing.
- The Tier 1 suite passed against the current data layer, confirming it is internally consistent today; the tests lock that in against future hand-edits.

## Follow-ups

- Tier 3 (d3-geo landmark sampling of the render pipeline) and Tier 4 (Playwright smoke test) remain open from `docs/testing-strategy.md`; worth adding when a `data`-labeled change next touches sequences or boundaries.

Generated by Claude Code. Session: [Code-Workstation:Fáfnir]

---
_Generated by [Claude Code](https://claude.ai/code/session_01USU71eNJekLdeBM6LVFPq3)_