### PR TITLE
test: add Tier 3 pipeline integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Install test dependencies
+        run: npm ci
       - name: Run test suite
         run: node --test

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Thumbs.db
 .claude/worktrees/
 
 # Add stack-specific patterns below (node_modules/, dist/, __pycache__/, target/, etc.)
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ### Added
 
+- Tier 3 pipeline integration tests (`test/pipeline.test.js`) — resolve ~24 famous US landmarks through the real bundled TopoJSON + `d3-geo` projection to assert the geometry, projection, and data layer agree; sweep a coarse grid to prove no cell resolves to the unstyled `#888` fallback; and verify the geo-lookup extraction preserved `app.js`'s original behavior. Adds `d3-geo`/`topojson-client` as **test-only** devDependencies (the shipped site is unchanged) and a `npm ci` step to the CI `test` job.
 - Test suite (`test/`) — the first automated tests. Tier 1 data-integrity invariants (`test/data-integrity.test.js`) guard against the documented gray-`#888` failure mode and dropped-state bug; Tier 2 unit tests (`test/getsubstate.test.js`) pin `getSubstateKey`'s boundary overrides on both sides of every line. Runs on `node --test` with zero dependencies. Adds a `test` job to CI and a minimal test-only `package.json` (site stays dependency-free). Implements the first steps of `docs/testing-strategy.md`.
 - `docs/testing-strategy.md` — test coverage analysis and a tiered testing proposal (data-integrity invariants, `getSubstateKey` unit tests, rendering-pipeline integration, browser smoke test) for the currently untested codebase.
 - `README.md` — quick-start, sovereignty sequence summary, file map.
@@ -14,6 +15,7 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ### Changed
 
+- Extract the pure geometry→sequence lookup (`buildStateLookup`, `findSequence`) out of the `js/app.js` render IIFE into a new `js/lookup.js` module so it can be unit-tested in Node. Behavior-preserving — the render path is unchanged and an equivalence test pins that.
 - `scripts/protect-main.sh` — sync to canon v0.2.6: accepts optional `OWNER/REPO` arg, improved check-context detection (space-aware `/` heuristic), post-apply warning when a required context name isn't found in recent CI runs.
 - `.claude/settings.json` — retire old pre-commit changelog hook; update pre-push hook to canon v0.2.5 (issue number optional in slug, allow `chore/release-v*` branches).
 - `.github/PULL_REQUEST_TEMPLATE.md` — add `## Follow-ups` section; update test plan comment to canon v0.2.5 wording.

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   <script src="https://d3js.org/d3.v7.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/topojson-client@3/dist/topojson-client.min.js"></script>
   <script src="js/territories.js"></script>
+  <script src="js/lookup.js"></script>
   <script src="js/app.js"></script>
   <!-- To run: python3 -m http.server 8080  →  open http://localhost:8080 -->
 </body>

--- a/js/app.js
+++ b/js/app.js
@@ -27,34 +27,11 @@
 
   const path = d3.geoPath().projection(projection);
 
-  // Build state lookup with bounding boxes for fast rejection
-  const stateLookup = statesGeo.features
-    .map(f => {
-      const fips = String(f.id).padStart(2, '0');
-      const abbr = FIPS_TO_STATE[fips];
-      const seq  = abbr ? STATE_SOVEREIGNTY[abbr] : null;
-      if (!seq) return null;
-      const [[lon0, lat0], [lon1, lat1]] = d3.geoBounds(f);
-      return { feature: f, abbr, seq, key: seq.join('→'), lon0, lat0, lon1, lat1 };
-    })
-    .filter(Boolean);
-
-  // Sort largest states first (faster average lookup)
-  stateLookup.sort((a, b) =>
-    (b.lon1 - b.lon0) * (b.lat1 - b.lat0) - (a.lon1 - a.lon0) * (a.lat1 - a.lat0)
+  // Build state lookup with bounding boxes for fast rejection, sorted
+  // largest-first for faster average lookup (see js/lookup.js).
+  const stateLookup = buildStateLookup(
+    statesGeo.features, d3.geoBounds, FIPS_TO_STATE, STATE_SOVEREIGNTY,
   );
-
-  function findSequence(lonlat) {
-    const [lon, lat] = lonlat;
-    for (const s of stateLookup) {
-      if (lon < s.lon0 || lon > s.lon1 || lat < s.lat0 || lat > s.lat1) continue;
-      if (d3.geoContains(s.feature, lonlat)) {
-        const override = getSubstateKey(lon, lat, s.abbr);
-        return override !== null ? override : s.key;
-      }
-    }
-    return null;
-  }
 
   // Build grid
   const cells = [];
@@ -62,7 +39,7 @@
     for (let py = 0; py < H; py += CELL) {
       const lonlat = projection.invert([px + CELL / 2, py + CELL / 2]);
       if (!lonlat) continue;
-      const key = findSequence(lonlat);
+      const key = findSequence(stateLookup, lonlat, d3.geoContains, getSubstateKey);
       if (key) cells.push({ px, py, key });
     }
   }

--- a/js/lookup.js
+++ b/js/lookup.js
@@ -1,0 +1,44 @@
+// Geo-lookup — the pure geometry→sequence resolution, extracted from the render
+// pipeline so it can be unit-tested in Node. No DOM, no D3 globals: the D3
+// functions and data tables are passed in. See docs/testing-strategy.md (Tier 3).
+
+// Build the state lookup: one entry per continental state that has a sequence,
+// carrying a precomputed bounding box, sorted largest-area-first so most points
+// hit an early entry. `geoBounds` is d3.geoBounds.
+function buildStateLookup(features, geoBounds, fipsToState, stateSovereignty) {
+  return features
+    .map((f) => {
+      const fips = String(f.id).padStart(2, '0');
+      const abbr = fipsToState[fips];
+      const seq = abbr ? stateSovereignty[abbr] : null;
+      if (!seq) return null;
+      const [[lon0, lat0], [lon1, lat1]] = geoBounds(f);
+      return { feature: f, abbr, seq, key: seq.join('→'), lon0, lat0, lon1, lat1 };
+    })
+    .filter(Boolean)
+    .sort(
+      (a, b) =>
+        (b.lon1 - b.lon0) * (b.lat1 - b.lat0) - (a.lon1 - a.lon0) * (a.lat1 - a.lat0),
+    );
+}
+
+// Resolve a [lon, lat] to a sequence key, or null if it lands outside every
+// state. Bounding-box reject runs before the expensive geoContains (a documented
+// performance invariant). `geoContains` is d3.geoContains; `getSubstate` is
+// getSubstateKey.
+function findSequence(stateLookup, lonlat, geoContains, getSubstate) {
+  const [lon, lat] = lonlat;
+  for (const s of stateLookup) {
+    if (lon < s.lon0 || lon > s.lon1 || lat < s.lat0 || lat > s.lat1) continue;
+    if (geoContains(s.feature, lonlat)) {
+      const override = getSubstate(lon, lat, s.abbr);
+      return override !== null ? override : s.key;
+    }
+  }
+  return null;
+}
+
+// Node interop for tests — inert in the browser (no `module` global there).
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { buildStateLookup, findSequence };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,74 @@
+{
+  "name": "blockparty",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "blockparty",
+      "version": "0.0.0",
+      "devDependencies": {
+        "d3-geo": "^3.1.1",
+        "topojson-client": "^3.1.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,5 +5,9 @@
   "description": "Test-only tooling for the blockparty static site. The shipped site remains dependency-free and CDN-loaded; this manifest exists solely to run the Node test suite. CHANGELOG.md remains the source of truth for releases (see CLAUDE.md).",
   "scripts": {
     "test": "node --test"
+  },
+  "devDependencies": {
+    "d3-geo": "^3.1.1",
+    "topojson-client": "^3.1.0"
   }
 }

--- a/test/pipeline.test.js
+++ b/test/pipeline.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+// Tier 3 — rendering-pipeline integration tests. Exercises the real geo-lookup
+// (js/lookup.js) against the bundled TopoJSON, d3-geo's Albers/geoContains, and
+// the full territories.js data layer. Confirms projection + geometry + data all
+// agree, and that the extraction from app.js preserved behavior. See
+// docs/testing-strategy.md (Tier 3).
+
+const { test, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const {
+  FIPS_TO_STATE,
+  STATE_SOVEREIGNTY,
+  SEQUENCE_COLORS,
+  getSubstateKey,
+} = require('../js/territories.js');
+const { buildStateLookup, findSequence } = require('../js/lookup.js');
+
+let geoBounds;
+let geoContains;
+let states;
+let lookup;
+let resolve; // (lon, lat) -> sequence key or null
+
+before(async () => {
+  // d3-geo / topojson-client are ESM-only; load them dynamically.
+  const d3 = await import('d3-geo');
+  const topo = await import('topojson-client');
+  geoBounds = d3.geoBounds;
+  geoContains = d3.geoContains;
+
+  const us = JSON.parse(
+    readFileSync(path.join(__dirname, '../data/us-states.json'), 'utf8'),
+  );
+  states = topo.feature(us, us.objects.states);
+  lookup = buildStateLookup(states.features, geoBounds, FIPS_TO_STATE, STATE_SOVEREIGNTY);
+  resolve = (lon, lat) => findSequence(lookup, [lon, lat], geoContains, getSubstateKey);
+});
+
+// Famous places, chosen to sit unambiguously inside a region (away from the
+// crude linear override lines), spanning nearly every sequence.
+const landmarks = [
+  ['Detroit, MI', -83.05, 42.33, 'France→Britain→USA'],
+  ['Boston, MA', -71.06, 42.36, 'Britain→USA'],
+  ['Montpelier, VT', -72.58, 44.26, 'Britain→Vermont Republic→USA'],
+  ['Albany, NY', -73.75, 42.65, 'Netherlands→Britain→USA'],
+  ['Wilmington, DE', -75.55, 39.74, 'Sweden→Netherlands→Britain→USA'],
+  ['Miami, FL', -80.19, 25.76, 'Spain→Britain→Spain→USA'],
+  ['Bismarck, ND', -100.78, 46.81, 'France→Spain→France→USA'],
+  ['Santa Fe, NM', -105.94, 35.69, 'Spain→Mexico→USA'],
+  ['Salt Lake City, UT', -111.89, 40.76, 'Spain→Mexico→Deseret→USA'],
+  ['Sacramento, CA', -121.49, 38.58, 'Spain→Mexico→Bear Flag Republic→USA'],
+  ['Austin, TX', -97.74, 30.27, 'Spain→Mexico→Republic of Texas→USA'],
+  ['Portland, OR', -122.68, 45.52, 'Spain+Russia→Britain+USA→USA'],
+  // Sub-state overrides resolved through the real geometry:
+  ['Missoula, MT (W of Divide)', -113.99, 46.87, 'Spain+Russia→Britain+USA→USA'],
+  ['Billings, MT (E of Divide)', -108.5, 45.78, 'France→Spain→France→USA'],
+  ['Grand Junction, CO (W of Divide)', -108.55, 39.06, 'Spain→Mexico→USA'],
+  ['Denver, CO (E of Divide)', -104.99, 39.74, 'France→Spain→France→USA'],
+  ['Hammond, LA (Florida Parishes)', -90.1, 30.55, 'Spain→Britain→Spain→Republic of West Florida→USA'],
+  ['Shreveport, LA (Louisiana Purchase)', -93.75, 32.52, 'France→Spain→France→USA'],
+  ['Biloxi, MS (Gulf coast)', -88.89, 30.4, 'Spain→Britain→Spain→USA'],
+  ['Jackson, MS (interior)', -90.18, 32.3, 'Britain→USA'],
+  ['Mobile, AL (coast)', -88.04, 30.69, 'Spain→Britain→Spain→USA'],
+  ['Laredo, TX (Nueces Strip)', -99.51, 27.51, 'Spain→Mexico→Disputed→USA'],
+  ['OK Panhandle (No Man\'s Land)', -101.5, 36.7, 'Spain→Mexico→Republic of Texas→Unorganized→USA'],
+  ['Oklahoma City, OK (main body)', -97.5, 35.47, 'France→Spain→France→USA'],
+];
+
+for (const [name, lon, lat, expected] of landmarks) {
+  test(`landmark resolves: ${name}`, () => {
+    assert.equal(resolve(lon, lat), expected);
+  });
+}
+
+test('lookup covers every state that has a sovereignty sequence', () => {
+  const lookupAbbrs = new Set(lookup.map((s) => s.abbr));
+  const sequenceStates = Object.keys(STATE_SOVEREIGNTY);
+  const missing = sequenceStates.filter((abbr) => !lookupAbbrs.has(abbr));
+  assert.deepEqual(missing, [], `states with a sequence but no geometry: ${missing.join(', ')}`);
+  assert.equal(lookupAbbrs.size, sequenceStates.length);
+});
+
+test('every lookup entry carries a key that has a color', () => {
+  for (const s of lookup) {
+    assert.ok(SEQUENCE_COLORS[s.key], `${s.abbr} key ${s.key} has no color`);
+  }
+});
+
+test('lookup is sorted largest-bbox-area first (performance invariant)', () => {
+  const area = (s) => (s.lon1 - s.lon0) * (s.lat1 - s.lat0);
+  for (let i = 1; i < lookup.length; i += 1) {
+    assert.ok(area(lookup[i - 1]) >= area(lookup[i]), `lookup not sorted at index ${i}`);
+  }
+});
+
+test('grid sweep never resolves to an unstyled (#888) cell', () => {
+  // Coarse sweep over the continental US; every resolved key must have a color.
+  let hits = 0;
+  for (let lon = -125; lon <= -66; lon += 1) {
+    for (let lat = 24; lat <= 49; lat += 1) {
+      const key = resolve(lon, lat);
+      if (key === null) continue;
+      hits += 1;
+      assert.ok(SEQUENCE_COLORS[key], `(${lon}, ${lat}) -> ${key} has no color`);
+    }
+  }
+  assert.ok(hits > 500, `expected a substantial land sample, got ${hits} hits`);
+});
+
+test('extraction preserves the original app.js lookup behavior', () => {
+  // Inline copy of the pre-extraction logic from app.js. Building the lookup and
+  // resolving both ways must agree everywhere — proves the refactor was a
+  // behavior-preserving move, not a rewrite.
+  const legacyLookup = states.features
+    .map((f) => {
+      const fips = String(f.id).padStart(2, '0');
+      const abbr = FIPS_TO_STATE[fips];
+      const seq = abbr ? STATE_SOVEREIGNTY[abbr] : null;
+      if (!seq) return null;
+      const [[lon0, lat0], [lon1, lat1]] = geoBounds(f);
+      return { feature: f, abbr, seq, key: seq.join('→'), lon0, lat0, lon1, lat1 };
+    })
+    .filter(Boolean);
+  legacyLookup.sort(
+    (a, b) =>
+      (b.lon1 - b.lon0) * (b.lat1 - b.lat0) - (a.lon1 - a.lon0) * (a.lat1 - a.lat0),
+  );
+  const legacyResolve = (lon, lat) => {
+    for (const s of legacyLookup) {
+      if (lon < s.lon0 || lon > s.lon1 || lat < s.lat0 || lat > s.lat1) continue;
+      if (geoContains(s.feature, [lon, lat])) {
+        const override = getSubstateKey(lon, lat, s.abbr);
+        return override !== null ? override : s.key;
+      }
+    }
+    return null;
+  };
+
+  for (let lon = -125; lon <= -66; lon += 1) {
+    for (let lat = 24; lat <= 49; lat += 1) {
+      assert.equal(resolve(lon, lat), legacyResolve(lon, lat), `mismatch at (${lon}, ${lat})`);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- Implements **Tier 3** of `docs/testing-strategy.md` — end-to-end coverage of the geometry→sequence resolution against the **real bundled TopoJSON** and the `d3-geo` Albers projection, closing the gap between the unit tests (Tiers 1–2, already on `main`) and the actual render pipeline.
- **Extracts the pure lookup** (`buildStateLookup`, `findSequence`) out of the `js/app.js` render IIFE into a new `js/lookup.js` module so it is importable in Node. Behavior-preserving — `app.js` and `index.html` are rewired to use it, and an equivalence test pins the result against an inline copy of the original logic.
- **`test/pipeline.test.js`**: resolves ~24 famous landmarks through the real geometry (spanning nearly every sequence, including sub-state overrides like the Continental Divide, Nueces Strip, and Florida Parishes); a coarse grid sweep asserting no cell resolves to the unstyled `#888` fallback; the largest-bbox-first sort invariant; and the extraction-equivalence check.
- Adds `d3-geo`/`topojson-client` as **test-only** devDependencies (+ `package-lock.json`), gitignores `node_modules/`, and adds a `npm ci` step to the CI `test` job. The shipped site is unchanged — still dependency-free and CDN-loaded.

## Test plan

- `npm ci && node --test` → **65 passing, 0 failing** (36 from Tiers 1–2 + 29 new).
- Verified `npm ci` reproduces the install from the committed lockfile.
- The equivalence test resolves ~1,500 grid points both through `js/lookup.js` and through an inline copy of the pre-extraction `app.js` logic and asserts they match — confirming the refactor did not change render behavior.

## Follow-ups

- Tier 4 (Playwright browser smoke test) remains the last open tier in `docs/testing-strategy.md`. The Chromium binary is available in the environment but the `playwright` package is not yet a dependency — worth adding as a self-contained next piece.

Generated by Claude Code. Session: [Code-Workstation:Fáfnir]

---
_Generated by [Claude Code](https://claude.ai/code/session_01USU71eNJekLdeBM6LVFPq3)_