### PR TITLE
chore: cut release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. Format based on [Keep a
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-06
+
 ### Added
 
 - Tier 4 browser smoke test (`e2e/smoke.mjs`, Playwright) — loads the real page in Chromium and asserts the render path end to end: the grid draws (>1000 cells), the legend has one item per distinct rendered sequence, the tooltip shows a sequence on hover and hides on leave, and the data-load failure branch shows its message. Hermetic — the D3/topojson CDN scripts are intercepted and served from local UMD bundles, so it needs no external network. Adds a `test:e2e` script, a `browser-test` CI job (installs Chromium), and `playwright`/`d3` test-only devDependencies. Completes the tiers proposed in `docs/testing-strategy.md`.


### PR DESCRIPTION
## Summary

- Cuts release **0.2.0** by moving the accumulated `[Unreleased]` changelog buffer into a `## [0.2.0] - 2026-08-06` section (the empty `[Unreleased]` heading is preserved).
- This release bundles the project's first automated test suite and the supporting infrastructure that landed since `0.1.0`.

### What's in 0.2.0

**Added**
- Test suite across four tiers — Tier 1 data-integrity invariants, Tier 2 `getSubstateKey` boundary units, Tier 3 pipeline integration (real geometry + `d3-geo` projection), Tier 4 Playwright browser smoke test. 69 tests total, gated by new `test` and `browser-test` CI jobs.
- `docs/testing-strategy.md` — the analysis and tiered plan that motivated the suite.
- `README.md`, `scripts/init-labels.sh`, `scripts/protect-main.sh`, `.github/release.yml`.

**Changed**
- Extracted the pure geometry→sequence lookup (`buildStateLookup`, `findSequence`) out of `js/app.js` into `js/lookup.js` (behavior-preserving; pinned by an equivalence test).
- WorldRover canon alignment pass (hooks, PR template, markdownlint/editorconfig, label scheme).

## Test plan

- Docs-only change to `CHANGELOG.md`; verified it passes markdownlint locally.
- No code changes in this PR — the full test suite already gates `main`.

## Follow-ups

- After merge: tag `v0.2.0` on `main` and publish the GitHub release from the 0.2.0 changelog entry (per `CLAUDE.md`).

Generated by Claude Code. Session: [Code-Workstation:Fáfnir]

---
_Generated by [Claude Code](https://claude.ai/code/session_01USU71eNJekLdeBM6LVFPq3)_